### PR TITLE
Makefile file and init error fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CC = gcc
 SRC = main.c
 
 all:
-	$(CC) $(CFLAGS) $(LDFLAGS) $(SRC) -o $(BIN)
+	$(CC) $(CFLAGS) $(SRC) $(LDFLAGS) -o $(BIN)
 
 run:
 	./$(BIN)

--- a/main.c
+++ b/main.c
@@ -214,7 +214,11 @@ static Point lerp(const Line l, const float n)
 // Setups the software gpu.
 static Gpu setup(const int xres, const int yres, const bool vsync)
 {
-    SDL_Init(SDL_INIT_VIDEO);
+    if (SDL_Init(SDL_INIT_VIDEO) != 0)
+    {
+        puts(SDL_GetError());
+        exit(1);
+    }
     SDL_Window* const window = SDL_CreateWindow(
         "littlewolf",
         SDL_WINDOWPOS_UNDEFINED,


### PR DESCRIPTION
I had a few problems getting littlewolf running as described in #8. I have made a couple of changes in this PR that might help others -

1. In the Makefile, move the LDFLAGS arguments to after the SRC file - this allows the project to compile under gcc in Ubuntu. I've also checked that it works on a MacOS, although I'm not really sure why the order of arguments matters on some platforms but not others.
2. Improve the error handling so that SDL_Init errors are reported correctly - previously if the init failed the error message reported wouldn't reflect to the root cause, but instead a later error due to the init failing.